### PR TITLE
prevent ssh timeouts

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,3 +2,12 @@
 # uncomment this to disable SSH key host checking
 host_key_checking = False
 hostfile = inventory/hosts
+
+
+# Uncomment to enable ansible pipelining
+# Makes ansible submit as many commands as possible in one go 
+# Only use this if requiretty is /etc/sudoers is false (default for Ubuntu)
+#pipelining=True
+
+# Don't timeout ssh for at least 30 min
+ssh_args = -o ControlPersist=1800s


### PR DESCRIPTION
If the AMI build process takes a long time, adding these lines to ansible.cfg can help prevent ansible from timing out over ssh. 
