### PR TITLE
Fixes autoscale group replacement

### DIFF
--- a/roles/rolling_asg/tasks/main.yml
+++ b/roles/rolling_asg/tasks/main.yml
@@ -26,7 +26,7 @@
     region: "{{ region }}"
     replace_all_instances: yes
     vpc_zone_identifier: "{{ asg_subnets | join(',') }}"
-  until: asg_result.viable_instances|int >= asg_desired_capacity|int
+  until: (asg_result is defined) and (asg_result.viable_instances|int >= asg_desired_capacity|int)
   delay: 10
   retries: 120
   register: asg_result


### PR DESCRIPTION
On an existing autoscaling group, I was getting an error object has no attribute 'viable_instances'

Waiting until said object is defined resolves this error.

See also https://github.com/ansible/ansible-modules-core/issues/2652
